### PR TITLE
Use versioned DB API views in worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# TideFly
+
+## DB API Views
+
+Background jobs read from versioned views: see [docs/api-contracts.md](docs/api-contracts.md).

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -1,0 +1,19 @@
+# API Contracts (DB Views)
+
+We expose a stable, versioned API from Postgres via schema-qualified **views**.  
+The worker consumes these instead of raw tables so schema changes don’t break jobs.
+
+## v1
+
+- `api.v1_spots` → maps `public.spots.primary_airport_iata` → `nearest_airport_iata`
+- `api.v1_alert_rules` → maps `public.alert_rules.destination_iata` → `dest_iata`
+  and provides placeholders (`regions`, `expires_at`) to match the worker’s select.
+
+**PostgREST paths:** `/rest/v1/api.v1_spots`, `/rest/v1/api.v1_alert_rules`
+
+## Evolving the contract
+
+- Don’t break `v1`. If internal tables change, **update the view definitions**.
+- For breaking changes, create `api.v2_*`, migrate clients, then retire `v1`.
+
+This lets frontend, worker(s), and BI tools rely on a stable shape over time.

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -403,7 +403,7 @@ def main():
     }
     # === NEW: load active alert rules (replaces user_spot_prefs path) ===
     rules = sb_select(
-        "alert_rules",
+        "api.v1_alert_rules",
         params={"is_active": "eq.true"},
         select=("id,user_id,name,mode,spot_id,regions,origin_iata,dest_iata,"
                 "min_wave_m,max_wind_kmh,min_nights,max_nights,max_price_eur,"
@@ -460,7 +460,7 @@ def main():
     spot_ids = sorted({r["spot_id"] for r in rules if r.get("mode") == "spot" and r.get("spot_id")})
     spots = {}
     for sid in spot_ids:
-        s = sb_select("spots", params={"id": "eq."+sid}, select="id,name,latitude,longitude,timezone,nearest_airport_iata")
+        s = sb_select("api.v1_spots", params={"id": "eq."+sid}, select="id,name,latitude,longitude,timezone,nearest_airport_iata")
         if s: spots[sid] = s[0]
 
     # Cache merged forecast per-spot so we compute it once per worker run


### PR DESCRIPTION
## Summary
- switch worker from raw tables to `api.v1_*` views
- document DB view contracts and link from README

## Testing
- `python -m py_compile worker/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4f2010f08832ba908ee0f382a5b09