### PR TITLE
Add resilient forecast fetching with retries and cache fallback

### DIFF
--- a/worker/db.py
+++ b/worker/db.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta, timezone
+import pandas as pd
+
+
+def load_recent_forecast_from_cache(sb_select_fn, spot_id, max_age_hours=12):
+    """Load cached forecast rows for a spot if newer than ``max_age_hours``.
+
+    Returns a DataFrame compatible with the live fetch output or ``None`` if
+    unavailable.
+    """
+    since = (datetime.now(timezone.utc) - timedelta(hours=max_age_hours)).isoformat()
+    try:
+        rows = sb_select_fn(
+            "forecast_cache",
+            params={
+                "spot_id": f"eq.{spot_id}",
+                "inserted_at": f"gt.{since}",
+            },
+            select="date,wave_stats,wind_stats",
+        )
+    except Exception as e:
+        print(f"[cache] load error spot_id={spot_id}: {e}")
+        return None
+
+    if not rows:
+        return None
+
+    df_rows = []
+    for r in rows:
+        wave = r.get("wave_stats") or {}
+        wind = r.get("wind_stats") or {}
+        try:
+            df_rows.append(
+                {
+                    "date": pd.to_datetime(str(r.get("date"))).normalize(),
+                    "min_wave": float(wave.get("min", 0)),
+                    "max_wave": float(wave.get("max", 0)),
+                    "avg_wave": float(wave.get("avg", 0)),
+                    "min_wind": float(wind.get("min", 0)),
+                    "max_wind": float(wind.get("max", 0)),
+                    "avg_wind": float(wind.get("avg", 0)),
+                }
+            )
+        except Exception:
+            continue
+
+    if not df_rows:
+        return None
+
+    return pd.DataFrame(df_rows)

--- a/worker/net.py
+++ b/worker/net.py
@@ -1,0 +1,38 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# Reusable session with retries and pooling
+_session = requests.Session()
+
+retry = Retry(
+    total=5,
+    connect=5,
+    read=5,
+    backoff_factor=0.8,
+    status_forcelist=[429, 500, 502, 503, 504],
+    allowed_methods=["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"],
+    raise_on_status=False,
+)
+
+adapter = HTTPAdapter(max_retries=retry, pool_connections=20, pool_maxsize=20)
+_session.mount("http://", adapter)
+_session.mount("https://", adapter)
+
+_session.headers.update({
+    "User-Agent": "TideFly/worker",
+    "Accept-Encoding": "gzip",
+})
+
+def get(url, params=None, timeout=(8, 20)):
+    """GET request using the shared session.
+
+    Args:
+        url (str): Target URL.
+        params (dict, optional): Query parameters.
+        timeout (tuple, optional): (connect, read) timeouts in seconds.
+
+    Returns:
+        requests.Response: The HTTP response.
+    """
+    return _session.get(url, params=params, timeout=timeout)

--- a/worker/utils.py
+++ b/worker/utils.py
@@ -1,0 +1,35 @@
+import time
+import concurrent.futures
+import requests
+
+
+def call_with_budget(fn, budget_seconds=35):
+    """Run ``fn`` with a time budget.
+
+    If ``fn`` exceeds ``budget_seconds`` or raises an error, log and return ``None``.
+    Always logs elapsed time.
+    """
+    start = time.time()
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            future = ex.submit(fn)
+            result = future.result(timeout=budget_seconds)
+        elapsed = time.time() - start
+        print(f"[budget] ok elapsed={elapsed:.2f}s")
+        return result
+    except concurrent.futures.TimeoutError:
+        elapsed = time.time() - start
+        print(f"[budget] timeout after {elapsed:.2f}s (limit {budget_seconds}s)")
+        return None
+    except requests.Timeout as e:
+        elapsed = time.time() - start
+        print(f"[budget] requests timeout after {elapsed:.2f}s: {e}")
+        return None
+    except requests.RequestException as e:
+        elapsed = time.time() - start
+        print(f"[budget] request error after {elapsed:.2f}s: {e}")
+        return None
+    except Exception as e:
+        elapsed = time.time() - start
+        print(f"[budget] error after {elapsed:.2f}s: {e}")
+        return None


### PR DESCRIPTION
## Summary
- implement shared HTTP session with retries, headers, and timeouts
- add `call_with_budget` helper to cap per-spot runtime
- fetch Open-Meteo data with minimal fields and cache fallback

## Testing
- `python -m py_compile worker/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7612449e8832b92d8641ea4f8bbb0