### PR TITLE
Improve forecast fetching and caching

### DIFF
--- a/worker/db.py
+++ b/worker/db.py
@@ -1,29 +1,73 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import pandas as pd
 
+def load_recent_forecast_from_cache(sb_select_fn, spot_id: str,
+                                    preferred_max_age_hours: int = 6,
+                                    hard_max_age_hours: int = 12):
+    """Return the latest cached forecast for ``spot_id`` if recent enough.
 
-def load_recent_forecast_from_cache(sb_select_fn, spot_id, max_age_hours=12):
-    """Load cached forecast rows for a spot if newer than ``max_age_hours``.
+    The function queries ``public.forecast_cache`` ordering by ``cached_at``
+    descending and limiting to the most recent row.  The age of that cache
+    snapshot determines whether it can be used:
 
-    Returns a DataFrame compatible with the live fetch output or ``None`` if
-    unavailable.
+    * ``age <= preferred_max_age_hours``  -> ``cache_fresh``
+    * ``age <= hard_max_age_hours``       -> ``cache_stale_ok``
+    * otherwise ``None`` is returned
+
+    The return value is a tuple ``(DataFrame, source)`` where ``source`` is the
+    cache state as above.  If no suitable cache exists ``(None, None)`` is
+    returned.
     """
-    since = (datetime.now(timezone.utc) - timedelta(hours=max_age_hours)).isoformat()
+
+    try:
+        latest = sb_select_fn(
+            "forecast_cache",
+            params={
+                "spot_id": f"eq.{spot_id}",
+                "order": "cached_at.desc",
+                "limit": "1",
+            },
+            select="date,wave_stats,wind_stats,cached_at",
+        )
+    except Exception as e:
+        print(f"[cache] load error spot_id={spot_id}: {e}")
+        return None, None
+
+    if not latest:
+        return None, None
+
+    row0 = latest[0]
+    cached_at_raw = row0.get("cached_at")
+    try:
+        cached_at = datetime.fromisoformat(str(cached_at_raw).replace("Z", "+00:00"))
+    except Exception:
+        return None, None
+
+    now = datetime.now(timezone.utc)
+    age_hours = (now - cached_at).total_seconds() / 3600.0
+    if age_hours > hard_max_age_hours:
+        print(f"[cache] spot_id={spot_id} cache_too_old age_h={age_hours:.2f}")
+        return None, None
+
+    state = "cache_fresh" if age_hours <= preferred_max_age_hours else "cache_stale_ok"
+
+    # Fetch all rows with the same cached_at timestamp so the caller gets the
+    # complete forecast snapshot.
     try:
         rows = sb_select_fn(
             "forecast_cache",
             params={
                 "spot_id": f"eq.{spot_id}",
-                "inserted_at": f"gt.{since}",
+                "cached_at": f"eq.{cached_at.isoformat()}",
             },
             select="date,wave_stats,wind_stats",
         )
     except Exception as e:
-        print(f"[cache] load error spot_id={spot_id}: {e}")
-        return None
+        print(f"[cache] load rows error spot_id={spot_id}: {e}")
+        return None, None
 
     if not rows:
-        return None
+        return None, None
 
     df_rows = []
     for r in rows:
@@ -45,6 +89,7 @@ def load_recent_forecast_from_cache(sb_select_fn, spot_id, max_age_hours=12):
             continue
 
     if not df_rows:
-        return None
+        return None, None
 
-    return pd.DataFrame(df_rows)
+    print(f"[cache] spot_id={spot_id} {state} age_h={age_hours:.2f} rows={len(df_rows)}")
+    return pd.DataFrame(df_rows), state


### PR DESCRIPTION
## Summary
- Split Open-Meteo calls into separate Marine and Weather requests, merge hourly data and log counts
- Add robust forecast cache lookup using `cached_at` with freshness checks
- Enhance HTTP client with tuned retry policy and automatic `raise_for_status`

## Testing
- `python -m py_compile worker/net.py worker/utils.py worker/db.py worker/worker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a772a8e4e4832bacb4827736fa8172