### PR TITLE
Add alert evaluation event logging with Decimal pricing

### DIFF
--- a/supabase/api/v1_rule_status.sql
+++ b/supabase/api/v1_rule_status.sql
@@ -1,0 +1,13 @@
+create or replace view api.v1_rule_status as
+  select distinct on (rule_id)
+    rule_id,
+    status,
+    price,
+    ok_dates_count,
+    tier,
+    reason,
+    created_at
+  from public.alert_events
+  order by rule_id, created_at desc;
+
+alter view api.v1_rule_status set (security_invoker = true);

--- a/vercel-app/api/v1_rule_status.js
+++ b/vercel-app/api/v1_rule_status.js
@@ -1,0 +1,12 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).send('Method Not Allowed');
+  const { rule_id } = req.query || {};
+  let url = process.env.SUPABASE_URL + '/rest/v1/api.v1_rule_status';
+  if (rule_id) url += `?rule_id=eq.${encodeURIComponent(rule_id)}`;
+  const r = await fetch(url, { headers: {
+    'apikey': process.env.SUPABASE_SERVICE_KEY,
+    'Authorization': 'Bearer ' + process.env.SUPABASE_SERVICE_KEY
+  }});
+  const data = await r.json();
+  res.status(200).json(data);
+}


### PR DESCRIPTION
## Summary
- log every alert rule evaluation with status and pricing info
- use Decimal money helpers for precise price comparisons
- expose latest alert status via new API and database view

## Testing
- `python -m py_compile worker/worker.py`
- `node --check vercel-app/api/v1_rule_status.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a77cf73334832bbf60b62b8b41533b