### PR TITLE
feat: surface rule status on alerts list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ vercel-app/.env*
 
 # Dependencies
 vercel-app/node_modules
+vercel-app/.next
+vercel-app/next-env.d.ts

--- a/vercel-app/components/StatusPill.tsx
+++ b/vercel-app/components/StatusPill.tsx
@@ -1,0 +1,12 @@
+export function StatusPill({ status }: { status?: string }) {
+  const map = {
+    sent: { label: 'Hit sent', cls: 'bg-green-100 text-green-800' },
+    too_pricey: { label: 'Too pricey', cls: 'bg-amber-100 text-amber-800' },
+    no_surf: { label: 'No surf', cls: 'bg-gray-100 text-gray-700' },
+    forecast_unavailable: { label: 'Forecast issue', cls: 'bg-red-100 text-red-800' },
+  } as const;
+  const m = status ? map[status as keyof typeof map] : undefined;
+  const label = m?.label ?? 'No data';
+  const cls = m?.cls ?? 'bg-slate-100 text-slate-700';
+  return <span className={`text-xs px-2 py-1 rounded-full ${cls}`}>{label}</span>;
+}


### PR DESCRIPTION
## Summary
- show rule status pill for each alert
- fetch latest rule statuses from `api.v1_rule_status`
- render relative time, price, and OK count when available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a78c6082fc832bbcb863c545ef49d8