### PR TITLE
Package worker and switch to module entry point

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -45,4 +45,4 @@ jobs:
       - run: pip install -r worker/requirements.txt
 
       - name: Run worker (unbuffered)
-        run: python -u worker/worker.py
+        run: python -u -m worker.worker

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 ## DB API Views
 
 Background jobs read from versioned views: see [docs/api-contracts.md](docs/api-contracts.md).
+
+## Worker
+
+Run the worker from the repository root:
+
+```
+python -u -m worker.worker
+```

--- a/worker/events.py
+++ b/worker/events.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict
-from .utils import to_json_number
+from worker.utils import to_json_number
 
 
 def log_event(supabase, *, rule_id: str, status: str,

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -6,10 +6,10 @@ import re
 from decimal import Decimal
 
 from supabase import create_client, Client
-from net import get as http_get
-from utils import call_with_budget, as_money
-from events import log_event
-from db import load_recent_forecast_from_cache
+from worker.net import get as http_get
+from worker.utils import call_with_budget, as_money
+from worker.events import log_event
+from worker.db import load_recent_forecast_from_cache
 
 def _is_iata(x: str) -> bool:
     return bool(re.fullmatch(r"[A-Z]{3}", (x or "")))


### PR DESCRIPTION
## Summary
- package the worker code with `__init__.py`
- use absolute imports inside worker modules
- document and run the worker via `python -u -m worker.worker`

## Testing
- `pip install -r worker/requirements.txt`
- `python -u -m worker.worker` *(fails: Missing required env var: SUPABASE_URL)*
- `python -m py_compile worker/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a791169408832b9d578ab52526baf3