### PR TITLE
Use upsert and deterministic hashes for alert event logging

### DIFF
--- a/worker/utils.py
+++ b/worker/utils.py
@@ -37,6 +37,8 @@ def call_with_budget(fn, budget_seconds=35):
 
 
 def as_money(x) -> Decimal:
+    if x is None:
+        return None
     return Decimal(str(x)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 


### PR DESCRIPTION
## Summary
- Ensure alert events always get a tier (default `info`) and a summary hash
- Compute deterministic summary hashes for non-sent outcomes
- Upsert into `alert_events` on `(rule_id,summary_hash)` to avoid duplicates
- Make money helpers handle `None` safely

## Testing
- `python -m py_compile worker/events.py worker/utils.py worker/worker.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a79ea6b250832bb7a22d3700ecbed8