### PR TITLE
Ensure non-null ok_dates and consistent counts

### DIFF
--- a/worker/events.py
+++ b/worker/events.py
@@ -51,6 +51,9 @@ def log_event(
             rule_id=rule_id, status=status, ok_dates=ok_dates, price=price, deep_link=deep_link
         )
 
+    ok_list = list(ok_dates) if ok_dates is not None else []
+    count = ok_dates_count if ok_dates_count is not None else len(ok_list)
+
     safe_tier = tier or "info"
 
     payload: Dict[str, Any] = {
@@ -58,11 +61,11 @@ def log_event(
         "summary_hash": summary_hash,
         "status": status,  # uses existing column
         "price": to_json_number(price) if price is not None else None,
-        "ok_dates_count": ok_dates_count,
+        "ok_dates_count": count,
         "tier": safe_tier,
         "reason": reason,
         "deep_link": deep_link,
-        "ok_dates": list(ok_dates) if ok_dates is not None else None,
+        "ok_dates": ok_list,
         # sent_at is DB-managed (default now()); do not set here
     }
     payload = {k: v for k, v in payload.items() if v is not None}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -662,6 +662,8 @@ def main():
                 sb,
                 rule_id=rule["id"],
                 status="forecast_unavailable",
+                ok_dates=[],
+                ok_dates_count=0,
                 reason="marine/weather unavailable and no fresh cache",
             )
             print(f"[spot] {spot['name']} -> empty forecast merge, skipping")
@@ -709,6 +711,7 @@ def main():
                 sb,
                 rule_id=rule["id"],
                 status="no_surf",
+                ok_dates=[],
                 ok_dates_count=0,
                 reason="no surfable mornings in window",
             )
@@ -800,10 +803,10 @@ def main():
                 sb,
                 rule_id=rule["id"],
                 status="forecast_unavailable",
-                ok_dates_count=len(ok_dates),
+                ok_dates=[],
+                ok_dates_count=0,
                 tier=tier,
                 reason="flight price unavailable",
-                ok_dates=ok_dates,
             )
             continue
         raw_max = rule.get("max_price_eur")


### PR DESCRIPTION
## Summary
- Always send non-null ok_dates lists and consistent counts in `log_event`
- Update worker to send empty ok_dates/count for `no_surf` and `forecast_unavailable` events

## Testing
- `python -m py_compile worker/events.py worker/worker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a43818e4832bbfec90046469a75e