### PR TITLE
feat: add marketing landing page

### DIFF
--- a/vercel-app/app/alerts/layout.tsx
+++ b/vercel-app/app/alerts/layout.tsx
@@ -1,7 +1,33 @@
 "use client";
 
 import RequireAuth from "@/components/RequireAuth";
+import SignOutButton from "@/components/SignOutButton";
 
-export default function AlertsLayout({ children }: { children: React.ReactNode }) {
-  return <RequireAuth>{children}</RequireAuth>;
+export default function AlertsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <RequireAuth>
+      <div style={{ maxWidth: 900, margin: "24px auto", padding: "0 16px" }}>
+        <header
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 20,
+          }}
+        >
+          <h1 style={{ fontSize: 20, margin: 0 }}>TideFly</h1>
+          <nav style={{ display: "flex", gap: 12 }}>
+            <a href="/alerts">Alerts</a>
+            <a href="/alerts/new">New alert</a>
+            <SignOutButton />
+          </nav>
+        </header>
+        {children}
+      </div>
+    </RequireAuth>
+  );
 }

--- a/vercel-app/app/auth/page.tsx
+++ b/vercel-app/app/auth/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Auth } from "@supabase/auth-ui-react";
+import { ThemeSupa } from "@supabase/auth-ui-shared";
+import { supabase } from "@/lib/supabaseClient";
+
+export default function AuthPage() {
+  const router = useRouter();
+
+  // If already signed in, go straight to /alerts
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) router.replace("/alerts");
+    });
+
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === "SIGNED_IN" && session) router.replace("/alerts");
+      if (event === "SIGNED_OUT") router.replace("/");
+    });
+    return () => sub.subscription.unsubscribe();
+  }, [router]);
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-md">
+        <h1 className="text-2xl font-semibold mb-4">TideFly</h1>
+        {/* Primary: email + password. Users can switch to "Sign in" in the UI */}
+        <Auth
+          supabaseClient={supabase}
+          view="sign_up"
+          appearance={{ theme: ThemeSupa }}
+          theme="dark"
+          providers={[]} // add Google/GitHub later
+          redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL || "https://tide-fly.vercel.app"}/reset`}
+        />
+        <p className="text-sm text-zinc-400 mt-3">
+          Already have an account? Use the “Sign in” link in the form.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/vercel-app/app/layout.tsx
+++ b/vercel-app/app/layout.tsx
@@ -1,23 +1,9 @@
-import SignOutButton from "@/components/SignOutButton";
-
 export const metadata = { title: "TideFly", description: "Surf + flight alerts" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body style={{ fontFamily: "ui-sans-serif, system-ui", margin: 0 }}>
-        <div style={{ maxWidth: 900, margin: "24px auto", padding: "0 16px" }}>
-          <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 20 }}>
-            <h1 style={{ fontSize: 20, margin: 0 }}>TideFly</h1>
-            <nav style={{ display: "flex", gap: 12 }}>
-              <a href="/alerts">Alerts</a>
-              <a href="/alerts/new">New alert</a>
-              <SignOutButton />
-            </nav>
-          </header>
-          {children}
-        </div>
-      </body>
+      <body style={{ fontFamily: "ui-sans-serif, system-ui", margin: 0 }}>{children}</body>
     </html>
   );
 }

--- a/vercel-app/app/page.tsx
+++ b/vercel-app/app/page.tsx
@@ -1,44 +1,228 @@
-"use client";
-
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { Auth } from "@supabase/auth-ui-react";
-import { ThemeSupa } from "@supabase/auth-ui-shared";
-import { supabase } from "@/lib/supabaseClient";
-
-export default function Home() {
-  const router = useRouter();
-
-  // If already signed in, go straight to /alerts
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => {
-      if (data.session) router.replace("/alerts");
-    });
-
-    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === "SIGNED_IN" && session) router.replace("/alerts");
-      if (event === "SIGNED_OUT") router.replace("/");
-    });
-    return () => sub.subscription.unsubscribe();
-  }, [router]);
-
+export default function LandingPage() {
   return (
-    <main className="min-h-screen flex items-center justify-center p-6">
-      <div className="w-full max-w-md">
-        <h1 className="text-2xl font-semibold mb-4">TideFly</h1>
-        {/* Primary: email + password. Users can switch to "Sign in" in the UI */}
-        <Auth
-          supabaseClient={supabase}
-          view="sign_up"
-          appearance={{ theme: ThemeSupa }}
-          theme="dark"
-          providers={[]} // add Google/GitHub later
-          redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL || "https://tide-fly.vercel.app"}/reset`}
-        />
-        <p className="text-sm text-zinc-400 mt-3">
-          Already have an account? Use the “Sign in” link in the form.
+    <div>
+      <nav
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "16px 32px",
+        }}
+      >
+        <div style={{ fontWeight: 600 }}>TideFly</div>
+        <div style={{ display: "flex", gap: 24 }}>
+          <a href="#features">Features</a>
+          <a href="#pricing">Pricing</a>
+          <a href="#how">How it works</a>
+        </div>
+        <div style={{ display: "flex", gap: 16 }}>
+          <a href="/auth" style={{ textDecoration: "none" }}>
+            Sign in
+          </a>
+          <a
+            href="/auth"
+            style={{
+              padding: "8px 16px",
+              background: "#3b82f6",
+              color: "white",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
+          >
+            Start tracking waves
+          </a>
+        </div>
+      </nav>
+      <main style={{ textAlign: "center", padding: "60px 16px" }}>
+        <h1 style={{ fontSize: 48, marginBottom: 16 }}>
+          Never miss the perfect
+          <span
+            style={{
+              background: "linear-gradient(to right,#38bdf8,#2563eb)",
+              WebkitBackgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            {" "}wave again
+          </span>
+        </h1>
+        <p
+          style={{
+            maxWidth: 600,
+            margin: "0 auto 32px",
+            color: "#555",
+            fontSize: 18,
+          }}
+        >
+          Get intelligent surf alerts based on wave height, wind conditions, and
+          your travel preferences. Tidefly monitors global swell conditions so
+          you know when epic sessions await.
         </p>
-      </div>
-    </main>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            gap: 16,
+            marginBottom: 40,
+          }}
+        >
+          <a
+            href="/auth"
+            style={{
+              padding: "12px 24px",
+              background: "#3b82f6",
+              color: "white",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
+          >
+            Start tracking waves
+          </a>
+          <a
+            href="#"
+            style={{
+              padding: "12px 24px",
+              border: "1px solid #3b82f6",
+              color: "#3b82f6",
+              borderRadius: 8,
+              textDecoration: "none",
+            }}
+          >
+            Watch demo
+          </a>
+        </div>
+        <div
+          style={{
+            maxWidth: 800,
+            margin: "0 auto",
+            aspectRatio: "16 / 9",
+            background: "#000",
+            borderRadius: 8,
+          }}
+        ></div>
+      </main>
+      <section id="features" style={{ padding: "80px 16px" }}>
+        <h2 style={{ textAlign: "center", fontSize: 32, marginBottom: 24 }}>
+          Features
+        </h2>
+        <p style={{ textAlign: "center", maxWidth: 600, margin: "0 auto" }}>
+          Intelligent swell alerts, travel-friendly recommendations and more to
+          keep you on top of the waves.
+        </p>
+      </section>
+      <section id="how" style={{ padding: "80px 16px", background: "#f0f2f4" }}>
+        <h2 style={{ textAlign: "center", fontSize: 32, marginBottom: 24 }}>
+          How it works
+        </h2>
+        <p style={{ textAlign: "center", maxWidth: 600, margin: "0 auto" }}>
+          Set your preferred spots and travel filters, then let TideFly alert you
+          when conditions line up.
+        </p>
+      </section>
+      <section
+        id="pricing"
+        style={{ padding: "80px 16px", background: "#f9fafb" }}
+      >
+        <h2 style={{ textAlign: "center", fontSize: 32, marginBottom: 40 }}>
+          Choose your wave hunting plan
+        </h2>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            gap: 24,
+            flexWrap: "wrap",
+          }}
+        >
+          <div
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: 8,
+              padding: 24,
+              width: 280,
+              textAlign: "center",
+            }}
+          >
+            <h3 style={{ fontSize: 20, marginBottom: 8 }}>Wave Watcher</h3>
+            <p style={{ marginBottom: 16 }}>Casual beach days</p>
+            <p style={{ fontSize: 24, fontWeight: 600 }}>
+              $0<span style={{ fontSize: 16 }}>/mo</span>
+            </p>
+            <a
+              href="/auth"
+              style={{
+                marginTop: 16,
+                display: "inline-block",
+                padding: "8px 16px",
+                background: "#3b82f6",
+                color: "white",
+                borderRadius: 8,
+                textDecoration: "none",
+              }}
+            >
+              Start watching
+            </a>
+          </div>
+          <div
+            style={{
+              border: "2px solid #3b82f6",
+              borderRadius: 8,
+              padding: 24,
+              width: 280,
+              textAlign: "center",
+            }}
+          >
+            <h3 style={{ fontSize: 20, marginBottom: 8 }}>Surf Seeker</h3>
+            <p style={{ marginBottom: 16 }}>Find better waves</p>
+            <p style={{ fontSize: 24, fontWeight: 600 }}>
+              $19<span style={{ fontSize: 16 }}>/mo</span>
+            </p>
+            <a
+              href="/auth"
+              style={{
+                marginTop: 16,
+                display: "inline-block",
+                padding: "8px 16px",
+                background: "#3b82f6",
+                color: "white",
+                borderRadius: 8,
+                textDecoration: "none",
+              }}
+            >
+              Start seeking
+            </a>
+          </div>
+          <div
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: 8,
+              padding: 24,
+              width: 280,
+              textAlign: "center",
+            }}
+          >
+            <h3 style={{ fontSize: 20, marginBottom: 8 }}>Pro Rider</h3>
+            <p style={{ marginBottom: 16 }}>Chase the best swells</p>
+            <p style={{ fontSize: 24, fontWeight: 600 }}>
+              $39<span style={{ fontSize: 16 }}>/mo</span>
+            </p>
+            <a
+              href="/auth"
+              style={{
+                marginTop: 16,
+                display: "inline-block",
+                padding: "8px 16px",
+                background: "#3b82f6",
+                color: "white",
+                borderRadius: 8,
+                textDecoration: "none",
+              }}
+            >
+              Go pro
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add marketing-focused landing page with hero, features, and pricing
- move Supabase auth form to `/auth`
- keep alerts pages authenticated with dedicated layout and header

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acec4fd86c832b9db22690662b1e6a