### PR TITLE
chore: configure tailwindcss plugin

### DIFF
--- a/vercel-app/postcss.config.mjs
+++ b/vercel-app/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- fix PostCSS config to load `tailwindcss` plugin

## Testing
- `NEXT_PUBLIC_SUPABASE_URL="https://example.supabase.co" NEXT_PUBLIC_SUPABASE_ANON_KEY="dummy" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acfd2ed8f8832b963769349f1cf255