### PR TITLE
Fix sign-in navigation for auth page

### DIFF
--- a/vercel-app/app/auth/page.tsx
+++ b/vercel-app/app/auth/page.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { supabase } from "@/lib/supabaseClient";
 
 export default function AuthPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const view =
+    (searchParams.get("view") as "sign_in" | "sign_up" | null) || "sign_in";
+  const helperText =
+    view === "sign_in"
+      ? "Don't have an account? Use the \u201cSign up\u201d link in the form."
+      : "Already have an account? Use the \u201cSign in\u201d link in the form.";
 
   // If already signed in, go straight to /alerts
   useEffect(() => {
@@ -26,18 +33,16 @@ export default function AuthPage() {
     <main className="min-h-screen flex items-center justify-center p-6">
       <div className="w-full max-w-md">
         <h1 className="text-2xl font-semibold mb-4">TideFly</h1>
-        {/* Primary: email + password. Users can switch to "Sign in" in the UI */}
+        {/* Primary: email + password. Users can switch between views in the UI */}
         <Auth
           supabaseClient={supabase}
-          view="sign_up"
+          view={view}
           appearance={{ theme: ThemeSupa }}
           theme="dark"
           providers={[]} // add Google/GitHub later
           redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL || "https://tide-fly.vercel.app"}/reset`}
         />
-        <p className="text-sm text-zinc-400 mt-3">
-          Already have an account? Use the “Sign in” link in the form.
-        </p>
+        <p className="text-sm text-zinc-400 mt-3">{helperText}</p>
       </div>
     </main>
   );

--- a/vercel-app/app/page.tsx
+++ b/vercel-app/app/page.tsx
@@ -23,11 +23,11 @@ export default function LandingPage() {
           <a href="#how">How it works</a>
         </div>
         <div style={{ display: "flex", gap: 16 }}>
-          <a href="/auth" style={{ textDecoration: "none" }}>
+          <a href="/auth?view=sign_in" style={{ textDecoration: "none" }}>
             Sign in
           </a>
           <a
-            href="/auth"
+            href="/auth?view=sign_up"
             style={{
               padding: "8px 16px",
               background: "#3b82f6",
@@ -81,7 +81,7 @@ export default function LandingPage() {
           }}
         >
           <a
-            href="/auth"
+            href="/auth?view=sign_up"
             style={{
               padding: "12px 24px",
               background: "#3b82f6",
@@ -303,7 +303,7 @@ export default function LandingPage() {
               <li>Bullet point</li>
             </ul>
             <a
-              href="/auth"
+              href="/auth?view=sign_up"
               style={{
                 marginTop: 16,
                 display: "inline-block",
@@ -363,7 +363,7 @@ export default function LandingPage() {
               <li>Bullet point</li>
             </ul>
             <a
-              href="/auth"
+              href="/auth?view=sign_up"
               style={{
                 marginTop: 16,
                 display: "inline-block",
@@ -407,7 +407,7 @@ export default function LandingPage() {
               <li>Bullet point</li>
             </ul>
             <a
-              href="/auth"
+              href="/auth?view=sign_up"
               style={{
                 marginTop: 16,
                 display: "inline-block",


### PR DESCRIPTION
## Summary
- Route "Sign in" to the sign-in view
- Default auth page to query-driven sign-in or sign-up view with helper copy
- Direct call-to-action and plan links to sign-up

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'tailwindcss')*


------
https://chatgpt.com/codex/tasks/task_e_68ad2730a778832bb185deae8fb901b6