### PR TITLE
feat(auth): use dynamic site url

### DIFF
--- a/vercel-app/app/auth/page.tsx
+++ b/vercel-app/app/auth/page.tsx
@@ -48,7 +48,7 @@ function AuthContent() {
           appearance={{ theme: ThemeSupa }}
           theme="dark"
           providers={[]} // add Google/GitHub later
-          redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL || "https://tide-fly.vercel.app"}/reset`}
+          redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL || `https://${process.env.VERCEL_URL}`}/reset`}
         />
         <p className="text-sm text-zinc-400 mt-3">{helperText}</p>
       </div>


### PR DESCRIPTION
## Summary
- derive redirect URL from environment variables instead of hardcoding production domain

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3217baf8832ba53c691b31b0ee2d