### PR TITLE
Redirect to landing page after signing out

### DIFF
--- a/vercel-app/components/RequireAuth.tsx
+++ b/vercel-app/components/RequireAuth.tsx
@@ -10,12 +10,26 @@ export default function RequireAuth({ children }: { children: React.ReactNode })
 
   useEffect(() => {
     let active = true;
+
+    // Listen for auth state changes so users are redirected after signing out
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!active) return;
+      if (!session) router.replace("/");
+    });
+
+    // Initial check when component mounts
     supabase.auth.getSession().then(({ data }) => {
       if (!active) return;
       if (!data.session) router.replace("/");
       else setChecked(true);
     });
-    return () => { active = false; };
+
+    return () => {
+      active = false;
+      subscription.unsubscribe();
+    };
   }, [router]);
 
   if (!checked) return null; // could render a loader

--- a/vercel-app/components/SignOutButton.tsx
+++ b/vercel-app/components/SignOutButton.tsx
@@ -1,11 +1,17 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 
 export default function SignOutButton() {
+  const router = useRouter();
+
   return (
     <button
-      onClick={async () => { await supabase.auth.signOut(); }}
+      onClick={async () => {
+        await supabase.auth.signOut();
+        router.replace("/");
+      }}
       className="text-sm underline"
     >
       Sign out


### PR DESCRIPTION
## Summary
- Redirect signed-out users to the landing page via router
- Monitor auth state to automatically navigate away when session ends

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68adbf68de18832bbfdff7b9bf3d2b7c